### PR TITLE
Corregir implementación FCM para usar API moderna

### DIFF
--- a/static/js/fcm-notifications.js
+++ b/static/js/fcm-notifications.js
@@ -21,6 +21,15 @@ class FCMNotificationManager {
            firebase.messaging.isSupported();
   }
 
+  /**
+   * Obtiene las opciones de token para Firebase Messaging
+   * @returns {Object} Objeto con configuración VAPID si está disponible
+   * @private
+   */
+  getTokenOptions() {
+    return this.config.vapidKey ? { vapidKey: this.config.vapidKey } : {};
+  }
+
   async init() {
     console.log('🔥 Iniciando FCM...');
     
@@ -57,8 +66,7 @@ class FCMNotificationManager {
       });
 
       // Verificar si ya tenemos un token
-      const tokenOptions = this.config.vapidKey ? { vapidKey: this.config.vapidKey } : {};
-      this.token = await this.messaging.getToken(tokenOptions);
+      this.token = await this.messaging.getToken(this.getTokenOptions());
       if (this.token) {
         console.log('🔥 Token FCM existente:', this.token);
         this.updateUI(true, 'Notificaciones activas');
@@ -70,8 +78,7 @@ class FCMNotificationManager {
 
       // Escuchar cambios en el token
       this.messaging.onTokenRefresh(() => {
-        const tokenOptions = this.config.vapidKey ? { vapidKey: this.config.vapidKey } : {};
-        this.messaging.getToken(tokenOptions).then((refreshedToken) => {
+        this.messaging.getToken(this.getTokenOptions()).then((refreshedToken) => {
           console.log('🔥 Token FCM actualizado:', refreshedToken);
           this.saveToken(refreshedToken);
         });
@@ -118,8 +125,7 @@ class FCMNotificationManager {
       }
 
       // Obtener token FCM con configuración VAPID
-      const tokenOptions = this.config.vapidKey ? { vapidKey: this.config.vapidKey } : {};
-      this.token = await this.messaging.getToken(tokenOptions);
+      this.token = await this.messaging.getToken(this.getTokenOptions());
       
       if (this.token) {
         console.log('✅ Token FCM obtenido:', this.token);

--- a/static/js/fcm-notifications.js
+++ b/static/js/fcm-notifications.js
@@ -44,14 +44,11 @@ class FCMNotificationManager {
         this.app = firebase.app();
       }
 
+      // Registrar service worker primero
+      await this.registerServiceWorker();
+
       // Obtener messaging
       this.messaging = firebase.messaging();
-
-      // Configurar VAPID key
-      if (this.config.vapidKey) {
-        this.messaging.useServiceWorker(await this.registerServiceWorker());
-        this.messaging.usePublicVapidKey(this.config.vapidKey);
-      }
 
       // Configurar manejo de mensajes en foreground
       this.messaging.onMessage((payload) => {
@@ -60,7 +57,8 @@ class FCMNotificationManager {
       });
 
       // Verificar si ya tenemos un token
-      this.token = await this.messaging.getToken();
+      const tokenOptions = this.config.vapidKey ? { vapidKey: this.config.vapidKey } : {};
+      this.token = await this.messaging.getToken(tokenOptions);
       if (this.token) {
         console.log('🔥 Token FCM existente:', this.token);
         this.updateUI(true, 'Notificaciones activas');
@@ -72,7 +70,8 @@ class FCMNotificationManager {
 
       // Escuchar cambios en el token
       this.messaging.onTokenRefresh(() => {
-        this.messaging.getToken().then((refreshedToken) => {
+        const tokenOptions = this.config.vapidKey ? { vapidKey: this.config.vapidKey } : {};
+        this.messaging.getToken(tokenOptions).then((refreshedToken) => {
           console.log('🔥 Token FCM actualizado:', refreshedToken);
           this.saveToken(refreshedToken);
         });
@@ -118,8 +117,9 @@ class FCMNotificationManager {
         return false;
       }
 
-      // Obtener token FCM
-      this.token = await this.messaging.getToken();
+      // Obtener token FCM con configuración VAPID
+      const tokenOptions = this.config.vapidKey ? { vapidKey: this.config.vapidKey } : {};
+      this.token = await this.messaging.getToken(tokenOptions);
       
       if (this.token) {
         console.log('✅ Token FCM obtenido:', this.token);


### PR DESCRIPTION
- Eliminar uso obsoleto de useServiceWorker() y usePublicVapidKey()
- Usar getToken() con configuración vapidKey en lugar de métodos obsoletos
- Actualizar onTokenRefresh para usar API moderna de Firebase SDK v10
- Registrar service worker antes de inicializar messaging
- Solucionar error: 'this.messaging.useServiceWorker is not a function'
