### PR TITLE
Agregar widget FCM para sidebar faltante

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -67,7 +67,7 @@ jobs:
           HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
           HUGO_ENVIRONMENT: production
           TZ: Europe/Madrid
-          # Configuración de Firebase Cloud Messaging
+          # Firebase Cloud Messaging configuration
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
           FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}

--- a/layouts/partials/fcm-config.html
+++ b/layouts/partials/fcm-config.html
@@ -1,8 +1,8 @@
 <script>
-// Configuración de Firebase para notificaciones push
-// Esta configuración se inyecta desde GitHub Secrets en producción
+// Firebase configuration for push notifications
+// This configuration is injected from GitHub Secrets in production
 
-// Configuración de Firebase (se inyecta desde GitHub Secrets)
+// Firebase configuration (injected from GitHub Secrets)
 const firebaseConfig = {
   apiKey: "{{ getenv "FIREBASE_API_KEY" | default "demo-api-key" }}",
   authDomain: "{{ getenv "FIREBASE_AUTH_DOMAIN" | default "demo-project.firebaseapp.com" }}",
@@ -12,10 +12,10 @@ const firebaseConfig = {
   appId: "{{ getenv "FIREBASE_APP_ID" | default "1:123456789:web:abcdef" }}"
 };
 
-// VAPID key para FCM
+// VAPID key for FCM
 const fcmVapidKey = "{{ getenv "FCM_VAPID_KEY" | default "" }}";
 
-// Configuración global para FCM
+// Global configuration for FCM
 window.FCM_CONFIG = {
   firebase: firebaseConfig,
   vapidKey: fcmVapidKey,
@@ -24,11 +24,11 @@ window.FCM_CONFIG = {
   hasKeys: {{ if getenv "FIREBASE_API_KEY" }}true{{ else }}false{{ end }}
 };
 
-console.log('🔥 Firebase Config cargado:', window.FCM_CONFIG.environment);
+console.log('🔥 Firebase Config loaded:', window.FCM_CONFIG.environment);
 {{ if not (getenv "FIREBASE_API_KEY") -}}
-console.warn('⚠️ Configuración de Firebase no encontrada. Usando valores demo para desarrollo.');
-console.log('📋 Para configurar FCM, sigue las instrucciones en FCM-SETUP.md');
+console.warn('⚠️ Firebase configuration not found. Using demo values for development.');
+console.log('📋 To configure FCM, follow instructions in FCM-SETUP.md');
 {{ else -}}
-console.log('✅ Configuración de Firebase cargada desde variables de entorno');
+console.log('✅ Firebase configuration loaded from environment variables');
 {{ end -}}
 </script>

--- a/layouts/partials/fcm-notifications.html
+++ b/layouts/partials/fcm-notifications.html
@@ -1,4 +1,4 @@
-<!-- Componente de notificaciones push con Firebase Cloud Messaging -->
+<!-- Push notifications component with Firebase Cloud Messaging -->
 {{ partial "fcm-config.html" . }}
 
 <div class="push-notifications push-notifications--sidebar">
@@ -40,7 +40,7 @@
   </div>
 </div>
 
-<!-- Cargar Firebase SDK -->
+<!-- Load Firebase SDK -->
 <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-messaging-compat.js"></script>
 <script src="/js/fcm-notifications.js"></script>

--- a/layouts/partials/widgets/fcm-notifications.html
+++ b/layouts/partials/widgets/fcm-notifications.html
@@ -1,0 +1,10 @@
+<!-- Widget de notificaciones FCM para sidebar -->
+<aside class="widget widget--fcm-notifications">
+  <div class="widget__header">
+    <h3 class="widget__title">🔔 Notificaciones</h3>
+  </div>
+  
+  <div class="widget__content">
+    {{ partial "fcm-notifications.html" . }}
+  </div>
+</aside>

--- a/layouts/partials/widgets/fcm-notifications.html
+++ b/layouts/partials/widgets/fcm-notifications.html
@@ -1,4 +1,4 @@
-<!-- Widget de notificaciones FCM para sidebar -->
+<!-- FCM notifications widget for sidebar -->
 <aside class="widget widget--fcm-notifications">
   <div class="widget__header">
     <h3 class="widget__title">🔔 Notificaciones</h3>

--- a/static/js/fcm-notifications.js
+++ b/static/js/fcm-notifications.js
@@ -22,8 +22,8 @@ class FCMNotificationManager {
   }
 
   /**
-   * Obtiene las opciones de token para Firebase Messaging
-   * @returns {Object} Objeto con configuración VAPID si está disponible
+   * Gets token options for Firebase Messaging
+   * @returns {Object} Object with VAPID configuration if available
    * @private
    */
   getTokenOptions() {
@@ -124,7 +124,7 @@ class FCMNotificationManager {
         return false;
       }
 
-      // Obtener token FCM con configuración VAPID
+      // Get FCM token with VAPID configuration
       this.token = await this.messaging.getToken(this.getTokenOptions());
       
       if (this.token) {


### PR DESCRIPTION
- Crear layouts/partials/widgets/fcm-notifications.html que faltaba
- Resolver error de build: 'partial widgets/fcm-notifications.html not found'
- Widget wrapper que incluye el componente fcm-notifications.html existente
- Aplicar estilos CSS widget--fcm-notifications ya configurados
- Build local verificado sin errores