### PR TITLE
Fix: remove obsolete onTokenRefresh listener

### DIFF
--- a/static/js/fcm-notifications.js
+++ b/static/js/fcm-notifications.js
@@ -76,14 +76,6 @@ class FCMNotificationManager {
         this.updateUI(false, 'No suscrito');
       }
 
-      // Escuchar cambios en el token
-      this.messaging.onTokenRefresh(() => {
-        this.messaging.getToken(this.getTokenOptions()).then((refreshedToken) => {
-          console.log('🔥 Token FCM actualizado:', refreshedToken);
-          this.saveToken(refreshedToken);
-        });
-      });
-
       console.log('✅ FCM inicializado correctamente');
       return true;
 


### PR DESCRIPTION
- Remove onTokenRefresh() call which doesn't exist in Firebase SDK v10+
- Token refresh is handled automatically by Firebase in modern versions
- Fixes production error: 'this.messaging.onTokenRefresh is not a function'
- Simplify FCM initialization by removing deprecated API calls