### PR TITLE
feat: add Google Analytics 4 integration using Hugo's official config

### DIFF
--- a/FCM-NOTIFICATIONS-SETUP.md
+++ b/FCM-NOTIFICATIONS-SETUP.md
@@ -29,8 +29,8 @@ Ve a tu repositorio en GitHub > **Configuración** > **Secretos y variables** > 
 | Secreto | Descripción | Valor |
 |---------|-------------|-------|
 | `FIREBASE_PROJECT_ID` | ID del proyecto Firebase | Valor del campo `project_id` del JSON |
-| `FIREBASE_PRIVATE_KEY` | Clave privada | Valor completo del campo `private_key` del JSON |
-| `FIREBASE_CLIENT_EMAIL` | Email del cliente | Valor del campo `client_email` del JSON |
+| `FIREBASE_PRIVATE_KEY` | Clave privada | Valor completo del campo `private_key` del JSON. Debe incluir los delimitadores `-----BEGIN PRIVATE KEY-----` y `-----END PRIVATE KEY-----`. Si tienes problemas con los saltos de línea, reemplázalos por `\n`. |
+| `FIREBASE_CLIENT_EMAIL` | Email del cliente | Valor del campo `client_email` del JSON. Es obligatorio para que el workflow funcione. |
 | `FCM_TOPIC` | Tema FCM (opcional) | `mundo-dolphins-news` (por defecto) |
 
 #### Variables de Configuración (Opcionales)
@@ -145,18 +145,22 @@ on:
 
 ## ❗ Troubleshooting
 
+
+### Error: "Service account object must contain a string 'client_email' property."
+- El secreto `FIREBASE_CLIENT_EMAIL` es obligatorio. Asegúrate de copiar el valor exacto del campo `client_email` del JSON de la cuenta de servicio y añadirlo como secreto en GitHub.
+
 ### Error: "Invalid private key"
-- Asegúrate de que `FIREBASE_PRIVATE_KEY` incluye `-----BEGIN PRIVATE KEY-----` y `-----END PRIVATE KEY-----`
-- No modifiques los saltos de línea `\n` en la clave
+- Asegúrate de que `FIREBASE_PRIVATE_KEY` incluye `-----BEGIN PRIVATE KEY-----` y `-----END PRIVATE KEY-----`.
+- Si tienes problemas con los saltos de línea, reemplázalos por `\n`.
 
 ### Error: "Topic not found"
-- Verifica que el tema existe y tiene suscriptores
-- Los temas se crean automáticamente cuando el primer usuario se suscribe
+- Verifica que el tema existe y tiene suscriptores.
+- Los temas se crean automáticamente cuando el primer usuario se suscribe.
 
 ### No se envían notificaciones
-- Comprueba que hay usuarios suscritos al tema
-- Verifica los permisos de la cuenta de servicio Firebase
-- Revisa los logs del workflow en Acciones de GitHub
+- Comprueba que hay usuarios suscritos al tema.
+- Verifica los permisos de la cuenta de servicio Firebase.
+- Revisa los logs del workflow en Acciones de GitHub.
 
 ## 📊 Monitoreo
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # mundo-dolphins.github.io
+
+## Notificaciones push (FCM) para nuevos artículos
+
+El repositorio incluye un workflow de GitHub Actions que envía notificaciones push a través de Firebase Cloud Messaging (FCM) cada vez que se publica un nuevo artículo o podcast.
+
+Consulta la documentación detallada para la configuración y solución de problemas:
+
+- [🔔 FCM-NOTIFICATIONS-SETUP.md: Configuración de notificaciones push y troubleshooting](./FCM-NOTIFICATIONS-SETUP.md)
+- [⚡ FCM-SETUP.md: Configuración general de Firebase Cloud Messaging y claves VAPID](./FCM-SETUP.md)
+
+En estos archivos encontrarás instrucciones paso a paso para:
+- Crear y configurar la cuenta de servicio de Firebase
+- Añadir los secretos necesarios en GitHub Actions
+- Configurar el tema FCM y las variables opcionales
+- Solución de errores comunes
+
+Si tienes dudas, revisa primero esos documentos antes de abrir una incidencia.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -104,6 +104,10 @@ outputs:
   - RSS
   - HeadlessCMSConfig
 
+services:
+    googleAnalytics:
+      id: G-5BLTW0CSE0
+
 # Configuración de seguridad para permitir acceso a variables de entorno
 security:
   funcs:

--- a/layouts/partials/analytics.html
+++ b/layouts/partials/analytics.html
@@ -1,0 +1,12 @@
+{{/* layouts/partials/analytics.html - Google Analytics 4 (GA4) integration */}}
+{{ $ga_id := .Site.Config.Services.GoogleAnalytics.ID }}
+{{ if $ga_id }}
+<!-- Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ $ga_id }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '{{ $ga_id }}');
+</script>
+{{ end }}

--- a/layouts/partials/head_custom.html
+++ b/layouts/partials/head_custom.html
@@ -1,1 +1,2 @@
 {{ with .Site.Params.customHead }}{{ . | safeHTML }}{{ end }}
+{{ partial "analytics.html" . }}


### PR DESCRIPTION
- Created partial layouts/partials/analytics.html for GA4 tracking
- The partial uses .Site.Config.Services.GoogleAnalytics.ID as recommended by Hugo documentation
- Included the partial in head_custom.html for automatic analytics on all pages
- No environment variables required; configuration is managed via
