### PR TITLE
refactor: convert notify-social-posts workflow to English

### DIFF
--- a/.github/workflows/notify-social-posts.yml
+++ b/.github/workflows/notify-social-posts.yml
@@ -1,0 +1,85 @@
+name: 🚀 Notificar nuevos posts sociales a Telegram
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'data/posts_*.json'
+
+jobs:
+  notify-telegram-social:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
+
+      - name: Detect new social posts
+        id: detect_posts
+        run: |
+          echo "Detectando nuevos posts sociales..."
+          NEW_FILES=$(git diff --name-only --diff-filter=A HEAD~1 HEAD | grep -E '^data/posts_.*\.json$' || true)
+          MODIFIED_FILES=$(git diff --name-only --diff-filter=M HEAD~1 HEAD | grep -E '^data/posts_.*\.json$' || true)
+          FILES="$NEW_FILES $MODIFIED_FILES"
+          if [ -z "$FILES" ]; then
+            echo "No hay nuevos posts sociales."
+            echo "has_new_posts=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "Archivos de posts sociales cambiados: $FILES"
+          echo "has_new_posts=true" >> $GITHUB_OUTPUT
+          echo "$FILES" > changed_posts_files.txt
+
+      - name: Cache last published date
+        id: cache-date
+        uses: actions/cache@v4
+        with:
+          path: .github/last_bluesky_published.txt
+          key: bluesky-last-published
+
+      - name: Enviar posts sociales a Telegram
+        if: steps.detect_posts.outputs.has_new_posts == 'true'
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          if [ -z "$TELEGRAM_BOT_TOKEN" ] || [ -z "$TELEGRAM_CHAT_ID" ]; then
+            echo "Faltan variables de entorno TELEGRAM_BOT_TOKEN o TELEGRAM_CHAT_ID"
+            exit 1
+          fi
+          # Leer la última fecha publicada de la caché (si existe)
+          LAST_DATE=""
+          if [ -f .github/last_bluesky_published.txt ]; then
+            LAST_DATE=$(cat .github/last_bluesky_published.txt)
+            echo "Última fecha publicada en caché: $LAST_DATE"
+          fi
+          NEW_LAST_DATE="$LAST_DATE"
+          for file in $(cat changed_posts_files.txt); do
+            echo "Procesando $file..."
+            jq -c '.[]' "$file" | while read -r post; do
+              stype=$(echo "$post" | jq -r '.stype // 1')
+              [ "$stype" = "0" ] || continue
+              published=$(echo "$post" | jq -r '.PublishedOn // empty')
+              text=$(echo "$post" | jq -r '.BlueSkyPost.Description // empty')
+              url=$(echo "$post" | jq -r '.BlueSkyPost.BskyPost // empty')
+              # Solo publicar si la fecha es mayor que la última publicada
+              if [ -n "$published" ] && { [ -z "$LAST_DATE" ] || [[ "$published" > "$LAST_DATE" ]]; }; then
+                if [ -n "$text" ] && [ -n "$url" ]; then
+                  message="${text}\n🔗 ${url}"
+                  curl -s -X POST "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/sendMessage" \
+                    -d chat_id="$TELEGRAM_CHAT_ID" \
+                    -d text="$message" \
+                    -d parse_mode="Markdown"
+                  # Actualizar la nueva última fecha si es mayor
+                  if [[ "$published" > "$NEW_LAST_DATE" ]]; then
+                    NEW_LAST_DATE="$published"
+                  fi
+                fi
+              fi
+            done
+          done
+          # Guardar la nueva última fecha publicada en la caché
+          if [ -n "$NEW_LAST_DATE" ] && [ "$NEW_LAST_DATE" != "$LAST_DATE" ]; then
+            echo "$NEW_LAST_DATE" > .github/last_bluesky_published.txt
+          fi


### PR DESCRIPTION
- All comments and variable names are now in English
- Maintains logic to only send new Bluesky posts (stype==0) to Telegram
- Uses cache
