### PR TITLE
🔧 Añadir caché para el binario del verificador en los flujos de trabajo de episodios y publicaciones

### DIFF
--- a/.github/workflows/episodes.yml
+++ b/.github/workflows/episodes.yml
@@ -27,8 +27,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            checker
-            checker.tar.gz
+            ./checker
           key: checker-binary-${{ steps.release_info.outputs.tag_name }}
           restore-keys: |
             checker-binary-
@@ -146,6 +145,7 @@ jobs:
           
           echo "Binary downloaded successfully"
           tar -xzf checker.tar.gz
+          rm -f checker.tar.gz  # Clean up tar file after extraction
           chmod +x checker
           echo "Binary extracted and ready to use"
 
@@ -160,18 +160,21 @@ jobs:
         run: |
           ./checker rss --data ${GITHUB_WORKSPACE}/data
 
-      - name: Clean up
-        run: rm -f checker checker.tar.gz
+      - name: Clean up binary before commit
+        run: rm -f checker.tar.gz
 
-      - name: Commit and push changes
-        uses: devops-infra/action-commit-push@v0.11.4
+      - name: Add & Commit
+        id: add_commit
+        uses: EndBug/add-and-commit@v9.1.4
         with:
-          github_token: ${{ secrets.PUSH }}
-          commit_prefix: "Added new episodes"
-          target_branch: new-episodes
+          message: "Added new episodes"
+          add: "./data"
+          push: true
+          new_branch: new-episodes
 
       - name: Create pull request
         uses: devops-infra/action-pull-request@v0.6.1
+        if: steps.add_commit.outputs.committed == 'true'
         with:
           github_token: ${{ secrets.PUSH }}
           body: "**Automated pull request after adding new episodes**"

--- a/.github/workflows/posts.yml
+++ b/.github/workflows/posts.yml
@@ -29,8 +29,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            checker
-            checker.tar.gz
+            ./checker
           key: checker-binary-${{ steps.release_info.outputs.tag_name }}
           restore-keys: |
             checker-binary-
@@ -171,6 +170,7 @@ jobs:
           
           echo "Binary downloaded successfully"
           tar -xzf checker.tar.gz
+          rm -f checker.tar.gz  # Clean up tar file after extraction
           chmod +x checker
           echo "Binary extracted and ready to use"
 
@@ -184,9 +184,6 @@ jobs:
       - name: Run checker
         run: |
           ./checker social --data ${GITHUB_WORKSPACE}/data
-
-      - name: Clean up
-        run: rm -f checker checker.tar.gz
           
       - name: Add & Commit
         id: add_commit

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ static/api/
 static/vapid-config.json
 data/historical/
 act.secrets
+checker
+checker.tar.gz


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for both `episodes.yml` and `posts.yml` to add caching for the `checker` binary, which speeds up workflow runs by avoiding unnecessary downloads when the binary hasn't changed. The caching mechanism uses the latest release tag as the cache key, ensuring that the cache is updated whenever a new release is published. The workflows now conditionally download or prepare the binary based on cache hits.

**Caching improvements for the `checker` binary:**

* Added steps to fetch the latest release tag from GitHub and use it as a cache key for the `checker` binary in both `.github/workflows/episodes.yml` and `.github/workflows/posts.yml`. [[1]](diffhunk://#diff-e18f0754447e80a93aad788aa0847f8332e7d784497649199ca27b8370f32a0bR13-R37) [[2]](diffhunk://#diff-f0810e6291dd9be59fe22f7b74edb432b0d051b437e508dd8df15b81b8eb99a0R15-R39)
* Integrated the `actions/cache@v4` action to cache `checker` and `checker.tar.gz` using the release tag, with a fallback restore key. [[1]](diffhunk://#diff-e18f0754447e80a93aad788aa0847f8332e7d784497649199ca27b8370f32a0bR13-R37) [[2]](diffhunk://#diff-f0810e6291dd9be59fe22f7b74edb432b0d051b437e508dd8df15b81b8eb99a0R15-R39)

**Conditional workflow execution based on cache status:**

* Modified the "Download checker binary" step to only run if the cache was not hit, preventing redundant downloads. [[1]](diffhunk://#diff-e18f0754447e80a93aad788aa0847f8332e7d784497649199ca27b8370f32a0bR13-R37) [[2]](diffhunk://#diff-f0810e6291dd9be59fe22f7b74edb432b0d051b437e508dd8df15b81b8eb99a0R15-R39)
* Added a "Prepare cached binary" step to handle the case when the cache is hit, ensuring the binary is ready for use. [[1]](diffhunk://#diff-e18f0754447e80a93aad788aa0847f8332e7d784497649199ca27b8370f32a0bR152-R158) [[2]](diffhunk://#diff-f0810e6291dd9be59fe22f7b74edb432b0d051b437e508dd8df15b81b8eb99a0R177-R183)