### PR TITLE
Fix Hugo build by adding missing dependencies

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -52,11 +52,6 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - name: Go mod tidy & validate
-        run: |
-          go mod tidy
-          go mod verify
-        working-directory: .
       - name: ${{ matrix.script.name }}
         run: ${{ matrix.script.cmd }}
         working-directory: ${{ matrix.script.dir }}

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,7 @@ github.com/gosimple/slug v1.15.0 h1:wRZHsRrRcs6b0XnxMUBM6WK1U1Vg5B0R7VkIf1Xzobo=
 github.com/gosimple/slug v1.15.0/go.mod h1:UiRaFH+GEilHstLUmcBgWcI42viBN7mAb818JrYOeFQ=
 github.com/gosimple/unidecode v1.0.1 h1:hZzFTMMqSswvf0LBJZCZgThIZrpDHFXux9KeGmn6T/o=
 github.com/gosimple/unidecode v1.0.1/go.mod h1:CP0Cr1Y1kogOtx0bJblKzsVWrqYaqfNOnHzpgWw4Awc=
+github.com/pfadfinder-konstanz/hugo-dpsg v0.0.0-20241230153742-cfa903e0f4ac h1:FHllW9R+ybpaXLVWWydMXU5ugqdGZPXXMj4LwwEGtRw=
+github.com/pfadfinder-konstanz/hugo-dpsg v0.0.0-20241230153742-cfa903e0f4ac/go.mod h1:2XEzYZMoA15ktGbwbDZj+6C4YwkJoFZblFB7DnCK9H4=
+github.com/privatemaker/headless-cms v0.1.2 h1:uLCiN3k3Tr48WzOeWsIJ8S7TXOoMoOrz4KT2V7hisso=
+github.com/privatemaker/headless-cms v0.1.2/go.mod h1:ZcHkPZzL9yCsBdmn9FpoIW35snTyj1bDOfqT0ZFJoZE=


### PR DESCRIPTION
This pull request makes a minor update to the workflow configuration by removing a step related to Go module validation.

* Workflow simplification:
  * [`.github/workflows/hugo.yaml`](diffhunk://#diff-abe8dde089c8263b64aeeddfc2154a7387d4bb12cb5b561f4ad934c64af5f325L55-L59): Removed the "Go mod tidy & validate" step, which previously ran `go mod tidy` and `go mod verify` to ensure Go module dependencies were up to date and valid.