### PR TITLE
fix hugo build

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -62,6 +62,12 @@ jobs:
     env:
       HUGO_VERSION: 0.150.0
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
       - name: Cache Node.js modules
         uses: actions/cache@v4
         with:
@@ -106,6 +112,7 @@ jobs:
             --minify \
             --buildFuture \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
+        working-directory: .
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -55,6 +55,11 @@ jobs:
       - name: ${{ matrix.script.name }}
         run: ${{ matrix.script.cmd }}
         working-directory: ${{ matrix.script.dir }}
+      - name: Upload generated content
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated-content
+          path: content
 
   build:
     runs-on: ubuntu-latest
@@ -67,6 +72,12 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+
+      - name: Download generated content
+        uses: actions/download-artifact@v4
+        with:
+          name: generated-content
+          path: content
 
       - name: Cache Node.js modules
         uses: actions/cache@v4


### PR DESCRIPTION
This pull request updates the `.github/workflows/hugo.yaml` workflow to improve how generated content is managed between jobs and ensures the build process uses the correct working directory. The most important changes are grouped below:

**Content Artifact Management:**

* Added a step to the `generate-content` job to upload the generated `content` directory as an artifact, making it available for subsequent jobs.
* Added a step to the `build` job to download the previously uploaded `content` artifact, ensuring the build uses the generated content.

**Repository Checkout:**

* Added a step to the `build` job to check out the repository, including all submodules and full history, to provide the necessary source files for the build.

**Build Configuration:**

* Updated the Hugo build step to explicitly set the working directory to the repository root, ensuring commands are run in the correct context.
