### PR TITLE
Add default assignee and reviewer 'javiyt' for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,19 @@
+---
 version: 2
 updates:
-  - package-ecosystem: "github-actions" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "gomod"
-    directory: "/tools/validate-contracts"
-    schedule:
-      interval: "daily"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  assignees:
+  - javiyt
+  reviewers:
+  - javiyt
+- package-ecosystem: gomod
+  directory: "/tools/validate-contracts"
+  schedule:
+    interval: daily
+  assignees:
+  - javiyt
+  reviewers:
+  - javiyt


### PR DESCRIPTION
This PR adds 'javiyt' as the default assignee and reviewer for all Dependabot updates.

This ensures that Dependabot pull requests are automatically assigned to @javiyt for review.

Automated change via a script.
